### PR TITLE
Initialize OSRM service repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.stxxl
+data/odessa_oblast.osm.pbf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENT Guidelines
+
+- Keep `.stxxl` and large data files untracked.
+- Update `README.md`, `ROADMAP.md`, and `CHANGELOG.md` only when significant changes occur.
+- Run `docker build` and `docker run` to verify the container when modifying the Dockerfile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [Unreleased]
+- Initial repository structure

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM osrm/osrm-backend
+
+WORKDIR /data
+
+COPY data/odessa_oblast.osm.pbf /data/
+COPY .stxxl /root/.stxxl
+
+RUN osrm-extract -p /opt/car.lua /data/odessa_oblast.osm.pbf && \
+    osrm-partition /data/odessa_oblast.osrm && \
+    osrm-customize /data/odessa_oblast.osrm
+
+EXPOSE 5000
+
+CMD ["osrm-routed", "--algorithm", "mld", "/data/odessa_oblast.osrm"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# ORSM
+# OSRM Odessa
+
+This repository provides a Docker container setup for an OSRM service using data for the Odessa region. It can be built and run locally or deployed via GitHub Codespaces and Railway.
+
+## Repository Structure
+```
+osrm-odessa/
+├── data/
+│   └── odessa_oblast.osm.pbf
+├── Dockerfile
+├── .stxxl
+├── .gitignore
+└── README.md
+```
+
+The `data` directory should contain the `odessa_oblast.osm.pbf` map file downloaded from [Geofabrik](https://download.geofabrik.de/). The `.stxxl` file is required for disk-based caching during preprocessing and should contain:
+
+```
+disk=/tmp/stxxl,10G,syscall
+```
+
+Both `.stxxl` and the map file are ignored via `.gitignore`.
+
+## Usage
+### Build and Run Locally
+```
+docker build -t osrm-odessa .
+docker run -d -p 5000:5000 osrm-odessa
+```
+Then query the service:
+```
+curl "http://localhost:5000/route/v1/driving/30.7233,46.4825;30.7326,46.4775?overview=false"
+```
+
+### Deploy on Railway
+1. Create a new Railway project and connect this repository.
+2. Ensure the `PORT` environment variable is set to `5000`.
+3. Deploy the project and use the generated URL to query the service.
+
+### Notes
+- Replace `car.lua` with other profiles (e.g., `foot.lua`, `bicycle.lua`) if needed.
+- Update `odessa_oblast.osm.pbf` periodically for fresh routing data.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,5 @@
+# Roadmap
+
+- [ ] Initial OSRM container setup
+- [ ] Automate data updates
+- [ ] Deployment guide for Railway


### PR DESCRIPTION
## Summary
- add Dockerfile for OSRM
- add gitignore for data files and `.stxxl`
- document repository usage and structure in README
- provide basic ROADMAP, CHANGELOG and AGENT guidelines

## Testing
- `docker build -t osrm-odessa .` *(fails: Cannot connect to the Docker daemon)*
- `docker run -d -p 5000:5000 osrm-odessa` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_686e7f91069c832080421d327bbc0c43