### PR TITLE
Add data folder and API wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## [Unreleased]
 - Initial repository structure
+- Added `api` directory with a simple Flask wrapper

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This repository provides a Docker container setup for an OSRM service using data
 ## Repository Structure
 ```
 osrm-odessa/
+├── api/
+│   ├── app.py
+│   └── requirements.txt
 ├── data/
 │   └── odessa_oblast.osm.pbf
 ├── Dockerfile
@@ -31,6 +34,14 @@ Then query the service:
 ```
 curl "http://localhost:5000/route/v1/driving/30.7233,46.4825;30.7326,46.4775?overview=false"
 ```
+
+### Run the Simple API Wrapper
+Install dependencies and start the Flask app which proxies requests to the OSRM service:
+```
+pip install -r api/requirements.txt
+python api/app.py
+```
+The `OSRM_URL` environment variable can be used to point the wrapper to a remote OSRM instance.
 
 ### Deploy on Railway
 1. Create a new Railway project and connect this repository.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,3 +3,4 @@
 - [ ] Initial OSRM container setup
 - [ ] Automate data updates
 - [ ] Deployment guide for Railway
+- [ ] Simple API wrapper for OSRM

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,23 @@
+import os
+from flask import Flask, request, jsonify
+import requests
+
+app = Flask(__name__)
+OSRM_URL = os.environ.get('OSRM_URL', 'http://localhost:5000')
+
+@app.route('/route')
+def route():
+    start = request.args.get('start')
+    end = request.args.get('end')
+    if not start or not end:
+        return jsonify({'error': 'start and end required'}), 400
+    url = f"{OSRM_URL}/route/v1/driving/{start};{end}?overview=false"
+    try:
+        resp = requests.get(url)
+        resp.raise_for_status()
+        return jsonify(resp.json())
+    except requests.RequestException as e:
+        return jsonify({'error': str(e)}), 502
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,1 @@
+Place odessa_oblast.osm.pbf here.


### PR DESCRIPTION
## Summary
- create data directory with placeholder
- add a simple Flask API wrapper for OSRM requests
- document the API usage
- update roadmap and changelog

## Testing
- `python -m py_compile api/app.py`


------
https://chatgpt.com/codex/tasks/task_b_686e811a318083209077157ce5af0dd8