### PR TITLE
Добавление CORS и примера fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .stxxl
+__pycache__/
+api/__pycache__/
+data/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## [Unreleased]
 - Initial repository structure
 - Added `api` directory with a simple Flask wrapper
+- CORS для API и пример fetch на странице `/`

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ python api/app.py
 ```
 The `OSRM_URL` environment variable can be used to point the wrapper to a remote OSRM instance.
 
+### Пример fetch
+Запустить сервер и открыть `http://localhost:8080/` в браузере. На странице расположен
+пример JavaScript, выполняющий `fetch` к API и выводящий ответ.
+
 ### Deploy on Railway
 1. Create a new Railway project and connect this repository.
 2. Ensure the `PORT` environment variable is set to `5000`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,4 +3,5 @@
 - [ ] Initial OSRM container setup
 - [ ] Automate data updates
 - [ ] Deployment guide for Railway
-- [ ] Simple API wrapper for OSRM
+- [x] Simple API wrapper for OSRM
+- [x] Поддержка CORS и пример Fetch

--- a/api/app.py
+++ b/api/app.py
@@ -1,9 +1,19 @@
+"""Простая обёртка Flask для обращений к OSRM."""
+
 import os
 from flask import Flask, request, jsonify
+from flask_cors import CORS
 import requests
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder="static", static_url_path="")
+CORS(app, resources={r"/*": {"origins": "*"}}, send_wildcard=True)
 OSRM_URL = os.environ.get('OSRM_URL', 'http://localhost:5000')
+
+
+@app.route('/')
+def index():
+    """Отдаёт пример использования API."""
+    return app.send_static_file('index.html')
 
 @app.route('/route')
 def route():

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 requests
+flask-cors

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -1,0 +1,20 @@
+<!-- Пример страницы с fetch-запросом к API -->
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>OSRM Demo</title>
+</head>
+<body>
+  <h1>Пример запроса</h1>
+  <pre id="out"></pre>
+  <script>
+  fetch('/route?start=30.7233,46.4825&end=30.7326,46.4775')
+    .then(r => r.json())
+    .then(j => {
+      document.getElementById('out').textContent = JSON.stringify(j, null, 2);
+    })
+    .catch(err => console.error(err));
+  </script>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,38 @@
+"""Тесты устойчивости и CORS для Flask API."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.path.append('api')
+from app import app
+
+
+def _mock_resp():
+    resp = MagicMock()
+    resp.json.return_value = {"routes": ["ok"]}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+@patch('app.requests.get', return_value=_mock_resp())
+def test_route(mock_get):
+    client = app.test_client()
+    r = client.get('/route?start=1,1&end=2,2')
+    assert r.status_code == 200
+    assert r.get_json() == {"routes": ["ok"]}
+
+
+@patch('app.requests.get', return_value=_mock_resp())
+def test_cors_header(mock_get):
+    client = app.test_client()
+    r = client.get('/route?start=1,1&end=2,2', headers={'Origin': 'http://ex.com'})
+    assert r.headers.get('Access-Control-Allow-Origin') == '*'
+
+
+@patch('app.requests.get', return_value=_mock_resp())
+def test_stability(mock_get):
+    client = app.test_client()
+    for _ in range(10):
+        r = client.get('/route?start=1,1&end=2,2')
+        assert r.status_code == 200
+


### PR DESCRIPTION
## Summary
- расширен Flask API с поддержкой CORS
- добавлена тестовая HTML‑страница с `fetch`
- внесены правки в документацию
- созданы тесты устойчивости и работы CORS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e9527d7788320a878af2315c036a2