### PR TITLE
Fix Python 3.5 compatibility in API

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -21,7 +21,7 @@ def route():
     end = request.args.get('end')
     if not start or not end:
         return jsonify({'error': 'start and end required'}), 400
-    url = f"{OSRM_URL}/route/v1/driving/{start};{end}?overview=false"
+    url = "{}/route/v1/driving/{};{}?overview=false".format(OSRM_URL, start, end)
     try:
         resp = requests.get(url)
         resp.raise_for_status()


### PR DESCRIPTION
## Summary
- ensure compatibility with older Python versions by replacing f-string in `api/app.py`

## Testing
- `pip install -q -r api/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686eaa358de88320a049d22a05e1a132