### PR TITLE
Add fallback routing via nearest reachable points

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -97,7 +97,14 @@ def trip():
 
 def _route_summary(points, params):
     """Формирует JSON с оригинальным ответом OSRM и кратким резюме."""
-    route_response = router.route_points(points, **params)
+    coordinates = [coord for coord in points.split(';') if coord]
+    if len(coordinates) >= 2:
+        start = coordinates[0]
+        end = coordinates[-1]
+        via_points = coordinates[1:-1] or None
+        route_response = router.route(start, end, via=via_points, **params)
+    else:
+        route_response = router.route_points(points, **params)
     summary = build_route_summary(route_response)
     return {
         'route': route_response,

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -11,7 +11,7 @@ import routing.router as router_module
 
 def _mock_resp():
     resp = MagicMock()
-    resp.json.return_value = {"ok": True}
+    resp.json.return_value = {"code": "Ok", "routes": [{}]}
     resp.raise_for_status.return_value = None
     return resp
 
@@ -33,6 +33,84 @@ def test_route_with_via_points():
         args, kwargs = mock_get.call_args
         assert args[0].endswith('/route/v1/driving/1,1;2,2;3,3;4,4')
         assert kwargs['params']['steps'] == 'true'
+
+
+def test_route_fallback_to_nearest_points():
+    router = router_module.Router("http://example.com")
+
+    route_responses = iter([
+        {"code": "NoRoute", "routes": []},
+        {"code": "Ok", "routes": [{"distance": 1000.0}], "waypoints": []}
+    ])
+    nearest_responses = iter([
+        {"code": "Ok", "waypoints": [
+            {"location": [1.1, 2.2]},
+            {"location": [1.2, 2.3]}
+        ]},
+        {"code": "Ok", "waypoints": [
+            {"location": [3.3, 4.4]}
+        ]}
+    ])
+
+    def fake_get(url, params=None, timeout=None):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.status_code = 200
+        if '/route/v1/driving/' in url:
+            payload = next(route_responses)
+        else:
+            payload = next(nearest_responses)
+        resp.json.return_value = payload
+        return resp
+
+    with patch('routing.router.requests.get', side_effect=fake_get) as mock_get:
+        result = router.route('1,1', '2,2')
+
+        assert result['code'] == 'Ok'
+        assert result['routes']
+
+        first_route_call = mock_get.call_args_list[0]
+        assert first_route_call.args[0].endswith('/route/v1/driving/1,1;2,2')
+
+        first_nearest_call = mock_get.call_args_list[1]
+        assert first_nearest_call.args[0].endswith('/nearest/v1/driving/1,1')
+        assert first_nearest_call.kwargs['params']['number'] == '5'
+
+        second_nearest_call = mock_get.call_args_list[2]
+        assert second_nearest_call.args[0].endswith('/nearest/v1/driving/2,2')
+        assert second_nearest_call.kwargs['params']['number'] == '5'
+
+        fallback_route_call = mock_get.call_args_list[3]
+        assert fallback_route_call.args[0].endswith('/route/v1/driving/1.100000,2.200000;3.300000,4.400000')
+
+
+def test_route_returns_original_when_fallback_not_possible():
+    router = router_module.Router("http://example.com")
+
+    route_responses = iter([
+        {"code": "NoRoute", "routes": []}
+    ])
+    nearest_responses = iter([
+        {"code": "Error", "waypoints": []}
+    ])
+
+    def fake_get(url, params=None, timeout=None):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.status_code = 200
+        if '/route/v1/driving/' in url:
+            payload = next(route_responses)
+        else:
+            payload = next(nearest_responses)
+        resp.json.return_value = payload
+        return resp
+
+    with patch('routing.router.requests.get', side_effect=fake_get) as mock_get:
+        result = router.route('1,1', '2,2')
+
+        assert result['code'] == 'NoRoute'
+        assert mock_get.call_args_list[1].args[0].endswith('/nearest/v1/driving/1,1')
+        assert len(mock_get.call_args_list) == 2
 
 
 def test_route_points_direct_call():


### PR DESCRIPTION
## Summary
- add fallback logic that snaps start and end to nearest routable locations when OSRM cannot build a route
- reuse the fallback-aware routing inside the summary endpoint for consistent distance calculations
- extend router and API tests to cover the new behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f927d8a3b88320baa0f71b8a2e1aeb